### PR TITLE
Fix issue of generating wrong nt2 values for buckingham in MBX files

### DIFF
--- a/mbfit/fitting/generate_software_files.py
+++ b/mbfit/fitting/generate_software_files.py
@@ -427,7 +427,7 @@ def generate_software_files(settings_path, config_file, mon_ids, do_ttmnrg, mbnr
             my_buckingham_text += "\n"
 
         number_of_types_2 = 0
-        if my_mon[0][0] > my_mon[1][0]:
+        if my_mon[0][1] > my_mon[1][1]:
             number_of_types_2 = max(my_number_types[my_mon[0][0]])
         else:
             number_of_types_2 = max(my_number_types[my_mon[1][0]])

--- a/mbfit/fitting/generate_software_files.py
+++ b/mbfit/fitting/generate_software_files.py
@@ -426,11 +426,7 @@ def generate_software_files(settings_path, config_file, mon_ids, do_ttmnrg, mbnr
                 my_buckingham_text += "        types{}.push_back({});\n".format(i + 1, my_number_types[my_mon[i][0]][j])
             my_buckingham_text += "\n"
 
-        number_of_types_2 = 0
-        if my_mon[0][1] > my_mon[1][1]:
-            number_of_types_2 = max(my_number_types[my_mon[0][0]])
-        else:
-            number_of_types_2 = max(my_number_types[my_mon[1][0]])
+        number_of_types_2 = max(my_number_types[my_mon[1][0]])
 
         my_buckingham_text += "        nt2 = {};\n\n".format(number_of_types_2 + 1)
 


### PR DESCRIPTION
nt2 was set to be the number atoms in the second printed molecule.