### PR TITLE
Changed bucktools comment from "C6" to "a"

### DIFF
--- a/mbfit/fitting/generate_software_files.py
+++ b/mbfit/fitting/generate_software_files.py
@@ -431,7 +431,7 @@ def generate_software_files(settings_path, config_file, mon_ids, do_ttmnrg, mbnr
         my_buckingham_text += "        nt2 = {};\n\n".format(number_of_types_2 + 1)
 
 
-        my_buckingham_text += "        // Fill in (in order) the C6 and d6 coefficients\n"
+        my_buckingham_text += "        // Fill in (in order) the a and d6 coefficients\n"
 
         A_units = "// kcal/mol"
         b_units = "// A^(-1)"


### PR DESCRIPTION
`my_buckingham_text` previously was the same as `my_dispersion_text`, even though they need slightly different variables. my_buckingham_text comment has been changed to mention `a` instead of `c6`.