### PR TITLE
Fixed a bug where MBX cpp code for long-range c6 initialization would be wrong for polyatomic monomers.

### DIFF
--- a/mbfit/fitting/file_writer_nb_fitting.py
+++ b/mbfit/fitting/file_writer_nb_fitting.py
@@ -844,9 +844,9 @@ void """ + system_keyword_polyholder + """_fit::write_cdl(std::ostream& os, unsi
         if use_lonepairs[i] != 0:
             atoms = list(fragments[i].get_atoms())
             a = "    monomer m{};\n".format(str(i + 1))
-            a += "    m{}.setup({}, w12, wcross, {}, {});\n".format(str(i + 1), get_coords_var_name(atoms[0][0], 1, char_code),
-                                                                    get_coords_var_name(atoms[3][0], 1, char_code),
-                                                                    get_coords_var_name(atoms[4][0], 2, char_code))
+            a += "    m{}.setup({}, w12, wcross, {}, {});\n".format(str(i + 1), get_coords_var_name(atoms[0][0], i+1, char_code),
+                                                                    get_coords_var_name(atoms[3][0], i*2+1, char_code),
+                                                                    get_coords_var_name(atoms[4][0], i*2+2, char_code))
             ff.write(a)
         char_code = chr(ord(char_code)+1)
 

--- a/mbfit/fitting/generate_software_files.py
+++ b/mbfit/fitting/generate_software_files.py
@@ -363,7 +363,7 @@ def generate_software_files(settings_path, config_file, mon_ids, do_ttmnrg, mbnr
                 c6index = sum(range(max(atom_types_number[0]) - atom_types_number[0][j] + 2, max(atom_types_number[0]) + 2))
                 print(c6index)
                 my_c6_long_range = C6[c6index]
-                my_c6_lr_text += "            c6_lr[nv * natoms + fst_ind] = {}; // {}\n".format(math.sqrt(my_c6_long_range), atom_types_letter[0][j])
+                my_c6_lr_text += "            c6_lr[nv * natoms + fst_ind + {}] = {}; // {}\n".format(j, math.sqrt(my_c6_long_range), atom_types_letter[0][j])
             my_c6_lr_text += "        }\n"
 
         if my_mon[0][0] == my_mon[1][0]:


### PR DESCRIPTION
Simple change to fix a problem where the lr_c6 variable in the generated MBX codes were not properly indexed.

Also included in this PR is a small fix to another indexing problem with performing fits for water with lone pairs.